### PR TITLE
Install uuid-runtime if needed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,7 @@ runs:
       id: create
       shell: bash
       run: |
+        which uuidgen || sudo apt -y install uuid-runtime
         UUID="$(uuidgen)"
         MNT="${{ inputs.root }}/${UUID}"
         echo ":rocket: Temp FS ${MNT} creation started" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Somehow, the action fails on Gitea runner because `uuidgen` is not installed by default.
Trying to install if missing...